### PR TITLE
Add podspec file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+We love contributions!
+
+Any contributions to the master apptentive-react-native project must sign the [Individual Contributor License Agreement (CLA)](https://docs.google.com/a/apptentive.com/spreadsheet/viewform?formkey=dDhMaXJKQnRoX0dRMzZNYnp5bk1Sbmc6MQ#gid=0). It's a doc that makes our lawyers happy and ensures we can provide a solid open source project.
+
+When you want to submit a change, send us a [pull request](https://github.com/apptentive/apptentive-react-native/pulls). Before we merge, we'll check to make sure you're on the list of people who've signed our CLA.
+
+Thanks!

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2011-2014, Apptentive, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Apptentive, Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL Apptentive, Inc. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/apptentive-react-native.podspec
+++ b/apptentive-react-native.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name         = "apptentive-react-native"
+  s.version      = "5.1.0"
+  s.summary      = "Apptentive SDK module for React Native"
+
+  s.description  = <<-DESC
+  React Native module for the Apptentive iOS SDK. 
+                   DESC
+
+  s.homepage     = "https://github.com/apptentive/apptentive-react-native"
+  s.license      = "BSD"
+  s.author             = { "Apptentive, Inc." => "info@apptentive.com" }
+  s.platform     = :ios
+  s.platform     = :ios, "9.0"
+  s.source       = { :git => "https://github.com/apptentive/apptentive-react-native.git", :tag => "v#{s.version}" }
+  s.source_files  = "ios/*.{h,m}"
+  s.public_header_files = "ios/*.h"
+  s.dependency "React"
+end


### PR DESCRIPTION
Adding this module while using CocoaPods to integrate React results in header files that can't be imported into this module. 

The podspec file allows the module itself to be integrated using CocoaPods, fixing the issue. 