### PR TITLE
Fix registration check to allow out-of-RN registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This document lets you know what has changed in the React Native module. For cha
 - [Android Changelog](https://github.com/apptentive/apptentive-android/blob/master/CHANGELOG.md)
 - [iOS Changelog](https://github.com/apptentive/apptentive-ios/blob/master/CHANGELOG.md)
 
+# 2018-08-15 - v5.1.4
+
+- Fixed Android build issues
+- Improved configuration handling
+
 # 2018-07-26 - v5.1.3
 
 - Fix check for registered status on iOS

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="apptentive_distribution">React Native</string>
-    <string name="apptentive_distribution_version">5.1.3</string>
+    <string name="apptentive_distribution_version">5.1.4</string>
 </resources>

--- a/apptentive-react-native.podspec
+++ b/apptentive-react-native.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "apptentive-react-native"
-  s.version = "5.1.3"
+  s.version = "5.1.4"
   s.summary      = "Apptentive SDK module for React Native"
 
   s.description  = <<-DESC

--- a/ios/RNApptentiveModule.m
+++ b/ios/RNApptentiveModule.m
@@ -62,7 +62,6 @@ RCT_EXPORT_METHOD(
 			[self sendEventWithName:@"onAuthenticationFailed" body:@{ @"reason": reasonString }];
 		};
 
-		_registered = YES;
 		resolve(configuration.distributionName);
 	} else {
 		rejecter(kRejectCode, @"Configuration returned nil", nil);
@@ -409,6 +408,10 @@ RCT_EXPORT_METHOD(
 
 RCT_EXPORT_MODULE()
 
+- (BOOL)isRegistered {
+	return Apptentive.shared.apptentiveKey != nil && Apptentive.shared.apptentiveSignature != nil;
+}
+
 - (NSArray<NSString *> *)supportedEvents
 {
 	return @[@"onUnreadMessageCountChanged", @"onAuthenticationFailed"];
@@ -450,4 +453,3 @@ RCT_EXPORT_MODULE()
 }
 
 @end
-

--- a/ios/RNApptentiveModule.m
+++ b/ios/RNApptentiveModule.m
@@ -52,7 +52,7 @@ RCT_EXPORT_METHOD(
 	if (configuration) {
 		configuration.appID = configurationDictionary[@"appleID"];
 		configuration.distributionName = @"React Native";
-		configuration.distributionVersion = @"5.1.3";
+		configuration.distributionVersion = @"5.1.4";
 		[Apptentive registerWithConfiguration:configuration];
 
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(messageCenterUnreadCountChangedNotification:) name:ApptentiveMessageCenterUnreadCountChangedNotification object:nil];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apptentive-react-native",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "React Native Module for Apptentive SDK",
   "main": "js/index.js",
   "scripts": {


### PR DESCRIPTION
The updated registration check broke the ability to register Apptentive from outside of React Native. 

We still don't have a perfect way of detecting successful registration, but checking to see if the app key and app signature (what this PR uses) are set are a pretty good proxy for an attempt at registration. 