### PR TITLE
Release 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This document lets you know what has changed in the React Native module. For cha
 - [Android Changelog](https://github.com/apptentive/apptentive-android/blob/master/CHANGELOG.md)
 - [iOS Changelog](https://github.com/apptentive/apptentive-ios/blob/master/CHANGELOG.md)
 
+# 2018-09-14 - v5.2.0
+
+- Allow registration of iOS SDK from native code
+- Apptentive Android SDK: 5.3.0
+- Apptentive iOS SDK: 5.2.0
+
 # 2018-08-15 - v5.1.4
 
 - Fixed Android build issues

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,6 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.apptentive:apptentive-android:5.1.5'
+    compile 'com.apptentive:apptentive-android:5.3.0'
 }
   

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="apptentive_distribution">React Native</string>
-    <string name="apptentive_distribution_version">5.1.4</string>
+    <string name="apptentive_distribution_version">5.2.0</string>
 </resources>

--- a/apptentive-react-native.podspec
+++ b/apptentive-react-native.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "apptentive-react-native"
-  s.version = "5.1.4"
+  s.version = "5.2.0"
   s.summary      = "Apptentive SDK module for React Native"
 
   s.description  = <<-DESC

--- a/ios/RNApptentiveModule.m
+++ b/ios/RNApptentiveModule.m
@@ -52,7 +52,7 @@ RCT_EXPORT_METHOD(
 	if (configuration) {
 		configuration.appID = configurationDictionary[@"appleID"];
 		configuration.distributionName = @"React Native";
-		configuration.distributionVersion = @"5.1.4";
+		configuration.distributionVersion = @"5.2.0";
 		[Apptentive registerWithConfiguration:configuration];
 
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(messageCenterUnreadCountChangedNotification:) name:ApptentiveMessageCenterUnreadCountChangedNotification object:nil];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apptentive-react-native",
-  "version": "5.1.4",
+  "version": "5.2.0",
   "description": "React Native Module for Apptentive SDK",
   "main": "js/index.js",
   "scripts": {

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -4,9 +4,13 @@ PODS:
 DEPENDENCIES:
   - apptentive-ios (= 5.1.2)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - apptentive-ios
+
 SPEC CHECKSUMS:
   apptentive-ios: b8f7f93cdec61e834f18f733fbb742094369445f
 
 PODFILE CHECKSUM: 027aa9c1233cd24527d576c0cafa829c237843c0
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.3

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -4,13 +4,9 @@ PODS:
 DEPENDENCIES:
   - apptentive-ios (= 5.1.2)
 
-SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
-    - apptentive-ios
-
 SPEC CHECKSUMS:
   apptentive-ios: b8f7f93cdec61e834f18f733fbb742094369445f
 
 PODFILE CHECKSUM: 027aa9c1233cd24527d576c0cafa829c237843c0
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.4.0


### PR DESCRIPTION
- Allow registration of iOS SDK from native code
- Apptentive Android SDK: 5.3.0
- Apptentive iOS SDK: 5.2.0