### PR TITLE
Fixed passing numbers as custom data for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This document lets you know what has changed in the React Native module. For cha
 - [Android Changelog](https://github.com/apptentive/apptentive-android/blob/master/CHANGELOG.md)
 - [iOS Changelog](https://github.com/apptentive/apptentive-ios/blob/master/CHANGELOG.md)
 
+# 2018-10-29 - v5.3.1
+
+- Apptentive Android SDK: 5.3.2
+- Apptentive iOS SDK: 5.2.2
+
 # 2018-09-14 - v5.3.0
 
 - Apptentive Android SDK: 5.3.1

--- a/android/src/main/java/com/apptentive/android/sdk/reactlibrary/RNApptentiveModule.java
+++ b/android/src/main/java/com/apptentive/android/sdk/reactlibrary/RNApptentiveModule.java
@@ -232,12 +232,18 @@ public class RNApptentiveModule extends ReactContextBaseJavaModule implements Un
 	}
 
 	@ReactMethod
-	public void addCustomPersonDataNumber(final String key, final Number value, final Promise promise) {
+	public void addCustomPersonDataNumber(final String key, final String value, final Promise promise) {
 		final String description = "add custom person data number";
 		dispatchConversationTask(new ConversationDispatchTask(new PromiseFailOnlyCallback(promise, description)) {
 			@Override
 			protected boolean execute(Conversation conversation) {
-				Apptentive.addCustomPersonData(key, value);
+				Number number = parseNumber(value);
+				if (number == null) {
+					promise.reject(CODE_APPTENTIVE, "Invalid number value: '" + value + "'");
+					return false;
+				}
+
+				Apptentive.addCustomPersonData(key, number);
 				promise.resolve(true);
 				return true;
 			}
@@ -284,12 +290,18 @@ public class RNApptentiveModule extends ReactContextBaseJavaModule implements Un
 	}
 
 	@ReactMethod
-	public void addCustomDeviceDataNumber(final String key, final Number value, final Promise promise) {
+	public void addCustomDeviceDataNumber(final String key, final String value, final Promise promise) {
 		final String description = "add custom device data number";
 		dispatchConversationTask(new ConversationDispatchTask(new PromiseFailOnlyCallback(promise, description)) {
 			@Override
 			protected boolean execute(Conversation conversation) {
-				Apptentive.addCustomDeviceData(key, value);
+				Number number = parseNumber(value);
+				if (number == null) {
+					promise.reject(CODE_APPTENTIVE, "Invalid number value: '" + value + "'");
+					return false;
+				}
+
+				Apptentive.addCustomDeviceData(key, number);
 				promise.resolve(true);
 				return true;
 			}
@@ -482,6 +494,22 @@ public class RNApptentiveModule extends ReactContextBaseJavaModule implements Un
 				}
 			}
 		}
+	}
+
+	//endregion
+
+	//region Helpers
+
+	private static @Nullable Number parseNumber(String value) {
+		try {
+			return Long.parseLong(value);
+		} catch (Exception ignored) {
+		}
+		try {
+			return Double.parseDouble(value);
+		} catch (Exception ignored) {
+		}
+		return null;
 	}
 
 	//endregion

--- a/js/index.js
+++ b/js/index.js
@@ -130,7 +130,7 @@ export class Apptentive {
       if (type === 'string') {
         return RNApptentiveModule.addCustomPersonDataString(key, value);
       } else if (type === 'number') {
-        return RNApptentiveModule.addCustomPersonDataNumber(key, value);
+        return RNApptentiveModule.addCustomPersonDataNumber(key, ApptentivePlatformSpecific.exportNumber(value));
       } else if (type === 'boolean') {
         return RNApptentiveModule.addCustomPersonDataBool(key, value);
       }

--- a/js/platform-specific.android.js
+++ b/js/platform-specific.android.js
@@ -4,6 +4,13 @@ export class ApptentivePlatformSpecific {
   static createApptentiveEventEmitter(nativeModule) {
     return DeviceEventEmitter;
   }
+
+  /** We need to serialize number to a string in order to retain the precision -
+   * Android library would automatically cast values to Integer.
+   */
+  static exportNumber(value) {
+    return value.toString()
+  }
 }
 
 module.exports = {

--- a/js/platform-specific.ios.js
+++ b/js/platform-specific.ios.js
@@ -4,6 +4,9 @@ export class ApptentivePlatformSpecific {
   static createApptentiveEventEmitter(nativeModule) {
     return new NativeEventEmitter(nativeModule);
   }
+  static exportNumber(value) {
+    return value
+  }
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apptentive-react-native",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "React Native Module for Apptentive SDK",
   "main": "js/index.js",
   "scripts": {


### PR DESCRIPTION
React-Native Android would only let to pass a specific subclass of `Number` (like `Integer`, `Double`, etc). In order to retain type information - we serialize `number` arguments to `string` and then parse it on the native side.

iOS passes the argument as-is.