### PR TITLE
Fix header search paths not to include the whole Pods folder

### DIFF
--- a/ios/RNApptentiveModule.xcodeproj/project.pbxproj
+++ b/ios/RNApptentiveModule.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -204,7 +205,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/../../../ios/Pods/**",
+					"$(SRCROOT)/../../../ios/Pods/apptentive-ios/**",
 					"$(inherited)",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
@@ -218,7 +219,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/../../../ios/Pods/**",
+					"$(SRCROOT)/../../../ios/Pods/apptentive-ios/**",
 					"$(inherited)",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";


### PR DESCRIPTION
Hi

Our React Native app mysteriously started breaking after I updated react-native-firebase to the latest version from 4.3.8. It gives an error such as 

```
CompileC ../node_modules/apptentive-react-native/ios/RNApptentiveModule.m normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.compiler
```

Seemingly unrelated error, but after a lot of googling and trying different stuff out, I realised it is because the header search paths in apptentive-react-native are looking *recursively* through the whole `ios/Pods` folder (`$(SRCROOT)/../../../ios/Pods`) and that has to somehow conflict with react-native-firebase's stuff. I think this recursive lookup might conflict with many other libs as well potentially.

Instead, the header search paths should be looked up from only the apptentive-ios folder ```$(SRCROOT)/../../../ios/Pods/apptentive-ios```

With this fix, I was able to build our project successfully.