### PR TITLE
Fix header search path issue (again) for RN 0.60

### DIFF
--- a/ios/RNApptentiveModule.xcodeproj/project.pbxproj
+++ b/ios/RNApptentiveModule.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../../ios/Pods/apptentive-ios/**",
 					"$(inherited)",
+					"\"$(SRCROOT)/../../../ios/Pods/Headers/Public/React-Core\"",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -221,6 +222,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../../ios/Pods/apptentive-ios/**",
 					"$(inherited)",
+					"\"$(SRCROOT)/../../../ios/Pods/Headers/Public/React-Core\"",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
For the 0.60+ release, RN team changed the Pod names they install from React to React-Core, and because of that apptentive gives an error `React/RCTEventEmitter.h file not found` in the `RNApptentiveModule.h`.

This commit fixes the search paths to include React-Core, which now includes the headers.