### PR TITLE
Release 5.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This document lets you know what has changed in the React Native module. For cha
 - [Android Changelog](https://github.com/apptentive/apptentive-android/blob/master/CHANGELOG.md)
 - [iOS Changelog](https://github.com/apptentive/apptentive-ios/blob/master/CHANGELOG.md)
 
+# 2019-10-29 - v5.4.4
+
+- Fixed `android` crash while configuration changes.
+- Apptentive Android SDK: 5.4.7
+- Apptentive iOS SDK: 5.2.7
+
 # 2019-06-21 - v5.4.3
 
 - Fix missing `ios` and `android` directories

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="apptentive_distribution">React Native</string>
-    <string name="apptentive_distribution_version">5.4.3</string>
+    <string name="apptentive_distribution_version">5.4.4</string>
 </resources>

--- a/ios/RNApptentiveModule.m
+++ b/ios/RNApptentiveModule.m
@@ -52,7 +52,7 @@ RCT_EXPORT_METHOD(
 	if (configuration) {
 		configuration.appID = configurationDictionary[@"appleID"];
 		configuration.distributionName = @"React Native";
-		configuration.distributionVersion = @"5.4.3";
+		configuration.distributionVersion = @"5.4.4";
 		[Apptentive registerWithConfiguration:configuration];
 
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(messageCenterUnreadCountChangedNotification:) name:ApptentiveMessageCenterUnreadCountChangedNotification object:nil];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apptentive-react-native",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "description": "React Native Module for Apptentive SDK",
   "main": "js/index.js",
   "types": "js/index.d.ts",

--- a/sample/ios/Podfile
+++ b/sample/ios/Podfile
@@ -6,6 +6,6 @@ target 'sample' do
   use_frameworks!
 
   # Pods for sample
-  pod 'apptentive-ios', '5.2.4'
+  pod 'apptentive-ios', '5.2.7'
 
 end

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - apptentive-ios (5.2.4)
+  - apptentive-ios (5.2.7)
 
 DEPENDENCIES:
-  - apptentive-ios (= 5.2.4)
+  - apptentive-ios (= 5.2.7)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - apptentive-ios
 
 SPEC CHECKSUMS:
-  apptentive-ios: bf18bf840887f0df730cd1e698e1570bf04ebf28
+  apptentive-ios: fc0c29a9599737240b5fe93d10d2a90150fb6b7a
 
-PODFILE CHECKSUM: af79d74ee7d8ab3f25a05da5c7ad10f25de46f6d
+PODFILE CHECKSUM: 3b112418f2faa6ed3cde7a7ee73502794a46f47c
 
-COCOAPODS: 1.7.2
+COCOAPODS: 1.5.3


### PR DESCRIPTION
- Fixed `android` crash while configuration changes.
- Apptentive Android SDK: 5.4.7
- Apptentive iOS SDK: 5.2.7