### PR TITLE
Release 5.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This document lets you know what has changed in the React Native module. For cha
 - [Android Changelog](https://github.com/apptentive/apptentive-android/blob/master/CHANGELOG.md)
 - [iOS Changelog](https://github.com/apptentive/apptentive-ios/blob/master/CHANGELOG.md)
 
+# 2019-11-05 - v5.4.5
+
+- Added `podspec` file and updated iOS header path for 0.60-style auto-linking.
+- Apptentive Android SDK: 5.4.7
+- Apptentive iOS SDK: 5.2.7
+
 # 2019-10-29 - v5.4.4
 
 - Fixed `android` crash while configuration changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This document lets you know what has changed in the React Native module. For cha
 - [Android Changelog](https://github.com/apptentive/apptentive-android/blob/master/CHANGELOG.md)
 - [iOS Changelog](https://github.com/apptentive/apptentive-ios/blob/master/CHANGELOG.md)
 
+# 2019-11-05 - v5.4.6
+
+- Fixed `podspec` file for 0.60-style auto-linking.
+- Apptentive Android SDK: 5.4.7
+- Apptentive iOS SDK: 5.2.7
+
 # 2019-11-05 - v5.4.5
 
 - Added `podspec` file and updated iOS header path for 0.60-style auto-linking.

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="apptentive_distribution">React Native</string>
-    <string name="apptentive_distribution_version">5.4.5</string>
+    <string name="apptentive_distribution_version">5.4.6</string>
 </resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="apptentive_distribution">React Native</string>
-    <string name="apptentive_distribution_version">5.4.4</string>
+    <string name="apptentive_distribution_version">5.4.5</string>
 </resources>

--- a/apptentive-react-native.podspec
+++ b/apptentive-react-native.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "apptentive-react-native"
-  s.version = "5.4.4"
+  s.version	 = '5.4.6'
   s.summary      = "Apptentive SDK module for React Native"
 
   s.description  = <<-DESC

--- a/ios/RNApptentiveModule.m
+++ b/ios/RNApptentiveModule.m
@@ -52,7 +52,7 @@ RCT_EXPORT_METHOD(
 	if (configuration) {
 		configuration.appID = configurationDictionary[@"appleID"];
 		configuration.distributionName = @"React Native";
-		configuration.distributionVersion = @"5.4.4";
+		configuration.distributionVersion = @"5.4.5";
 		[Apptentive registerWithConfiguration:configuration];
 
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(messageCenterUnreadCountChangedNotification:) name:ApptentiveMessageCenterUnreadCountChangedNotification object:nil];

--- a/ios/RNApptentiveModule.m
+++ b/ios/RNApptentiveModule.m
@@ -52,7 +52,7 @@ RCT_EXPORT_METHOD(
 	if (configuration) {
 		configuration.appID = configurationDictionary[@"appleID"];
 		configuration.distributionName = @"React Native";
-		configuration.distributionVersion = @"5.4.5";
+		configuration.distributionVersion = @"5.4.6";
 		[Apptentive registerWithConfiguration:configuration];
 
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(messageCenterUnreadCountChangedNotification:) name:ApptentiveMessageCenterUnreadCountChangedNotification object:nil];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apptentive-react-native",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "description": "React Native Module for Apptentive SDK",
   "main": "js/index.js",
   "types": "js/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apptentive-react-native",
-  "version": "5.4.5",
+  "version": "5.4.6",
   "description": "React Native Module for Apptentive SDK",
   "main": "js/index.js",
   "types": "js/index.d.ts",

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -5,7 +5,7 @@ DEPENDENCIES:
   - apptentive-ios (= 5.2.7)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  https://github.com/cocoapods/specs.git:
     - apptentive-ios
 
 SPEC CHECKSUMS:
@@ -13,4 +13,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 3b112418f2faa6ed3cde7a7ee73502794a46f47c
 
-COCOAPODS: 1.8.0
+COCOAPODS: 1.5.3

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -5,7 +5,7 @@ DEPENDENCIES:
   - apptentive-ios (= 5.2.7)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - apptentive-ios
 
 SPEC CHECKSUMS:
@@ -13,4 +13,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 3b112418f2faa6ed3cde7a7ee73502794a46f47c
 
-COCOAPODS: 1.7.2
+COCOAPODS: 1.8.0

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -5,7 +5,7 @@ DEPENDENCIES:
   - apptentive-ios (= 5.2.7)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - apptentive-ios
 
 SPEC CHECKSUMS:
@@ -13,4 +13,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 3b112418f2faa6ed3cde7a7ee73502794a46f47c
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.8.0


### PR DESCRIPTION
- Fixed `podspec` file for 0.60-style auto-linking.
- Apptentive Android SDK: 5.4.7
- Apptentive iOS SDK: 5.2.7