### PR TITLE
Updated dependencies for sample apps

### DIFF
--- a/sample/package.json
+++ b/sample/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "apptentive-react-native": "^5.4.1",
+    "apptentive-react-native": "^5.4.6",
     "react": "16.8.3",
     "react-native": "0.59.5"
   },

--- a/sample61/package.json
+++ b/sample61/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "apptentive-react-native": "^5.4.6",
+    "apptentive-react-native": "^5.5.0",
     "react": "16.9.0",
     "react-native": "0.61.4"
   },


### PR DESCRIPTION
Old `sample` app should only depend on `5.4.x`, the new `sample61` should use the latest aftifact.

@MatthewCallis, should we rename them to `sample-legacy` and `a-shiny-brand-new-awesome-sample` (or simply `sample`)?