### PR TITLE
Add a translatable=false attribute to apptentive_distribution strings

### DIFF
--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="apptentive_distribution">React Native</string>
-    <string name="apptentive_distribution_version">5.5.0</string>
+    <string name="apptentive_distribution" translatable="false">React Native</string>
+    <string name="apptentive_distribution_version" translatable="false">5.5.0</string>
 </resources>


### PR DESCRIPTION
Omitting this attributed causes Android Lint to flag these lines with the `MissingTranslation` issue. Since these strings don't appear to be intended to be translated (they just refer to a feature name/version), adding this attribute seems appropriate.

<img width="909" alt="Screen Shot 2020-03-06 at 3 20 37 PM" src="https://user-images.githubusercontent.com/8016136/76130146-99624280-5fbe-11ea-838e-f82d99fe9b55.png">

Discovered when I expanded our project Lint coverage to include React Native dependency libraries.