### PR TITLE
Repair Missing Header for iOS

### DIFF
--- a/apptentive-react-native.podspec
+++ b/apptentive-react-native.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m}"
   s.public_header_files = "ios/*.h"
   s.dependency "React"
-  s.dependency "apptentive-ios", "~>5"
+  s.dependency "apptentive-ios", ">= 5.3.1", "< 6.0"
 end

--- a/ios/RNApptentiveModule.m
+++ b/ios/RNApptentiveModule.m
@@ -1,5 +1,5 @@
 #import "RNApptentiveModule.h"
-#import "Apptentive.h"
+#import "ApptentiveMain.h"
 
 static NSString *const kRejectCode = @"ApptentiveModule";
 extern ApptentiveLogLevel ApptentiveLogLevelFromString(NSString *level);


### PR DESCRIPTION
Compatibility changes for iOS14 as introduced in native iOS SDK 5.3.1.