### PR TITLE
Change getContext() to return Activity Context

### DIFF
--- a/android/src/main/java/com/apptentive/android/sdk/reactlibrary/RNApptentiveModule.java
+++ b/android/src/main/java/com/apptentive/android/sdk/reactlibrary/RNApptentiveModule.java
@@ -432,7 +432,7 @@ public class RNApptentiveModule extends ReactContextBaseJavaModule implements Un
 	}
 
 	private Context getContext() {
-		return reactContextWrapper.getContext();
+		return reactContextWrapper.getCurrentActivity();
 	}
 
 	//region Unread Message Listener


### PR DESCRIPTION
Previously was returning an Application Context which prevented the Google Play Review Dialog from being shown for uncoupled rating interactions.