### PR TITLE
MAPP-2192: remove conditional imports

### DIFF
--- a/ios/RNApptentiveModule.h
+++ b/ios/RNApptentiveModule.h
@@ -1,9 +1,4 @@
-
-#if __has_include("RCTBridgeModule.h")
-#import "RCTEventEmitter.h"
-#else
 #import <React/RCTEventEmitter.h>
-#endif
 
 @interface RNApptentiveModule : RCTEventEmitter <RCTBridgeModule>
 


### PR DESCRIPTION
We had to create a patch for this library when updating ExpoAV and we need to tidy this up, as we want to avoid this temporary solution given it is code that we own.

https://economist.atlassian.net/browse/MAPP-2192