### PR TITLE
Remove broken prepare and release tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "test": "jest",
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
-    "prepare": "bob build",
-    "release": "release-it",
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",
     "bootstrap": "yarn example && yarn && yarn pods"


### PR DESCRIPTION
The `package.json` had a `prepare` script that tried to run a non-existent `build` task using `bob`. This PR removes it, along with the `release` script, since we want the SDK builder or its successor to handle releasing.  