### PR TITLE
Pbi 3755 - Fix typescript issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This document lets you know what has changed in the React Native module. For cha
 - [Android Changelog](https://github.com/apptentive/apptentive-android/blob/master/CHANGELOG.md)
 - [iOS Changelog](https://github.com/apptentive/apptentive-ios/blob/master/CHANGELOG.md)
 
+# 2022-07-20 - v6.0.2
+
+- Apptentive Android SDK: 5.8.3
+- Apptentive iOS SDK: 6.0.3
+
+#### Bugs Fixed
+
+- Fixed typescript functionality in published package
+
 # 2022-06-09 - v6.0.1
 
 - Apptentive Android SDK: 5.8.3

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "test": "jest",
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
+    "prepare": "bob build",
+    "release": "release-it",
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",
     "bootstrap": "yarn example && yarn && yarn pods"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apptentive-react-native",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "React Native Module for Apptentive SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
No actual changes to the code here, but in playing around with the published npm package, the script I ran (`npm run release-it`) updated the published version to 6.0.2, so this is just to keep the GitHub version in sync. 