### PR TITLE
Update ApptentiveKit dep to 6.0.6

### DIFF
--- a/apptentive-react-native.podspec
+++ b/apptentive-react-native.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'ApptentiveKit', '~> 6.0.2'
+  s.dependency 'ApptentiveKit', '~> 6.0.6'
   s.dependency "React-Core"
 end


### PR DESCRIPTION
Workaround for Apptentive issues on iOS.
