### PR TITLE
Normalize case of region string before looking it up

### DIFF
--- a/ios/ApptentiveModule.swift
+++ b/ios/ApptentiveModule.swift
@@ -28,7 +28,8 @@ import ApptentiveKit
       environment = .custom(overrideBaseURL)
     }
 
-    let region = (configuration["region"] as? String).flatMap { Apptentive.Region(rawValue: $0) } ?? .us
+    let regionString = (configuration["region"] as? String)?.lowercased()
+    let region = regionString.flatMap { Apptentive.Region(rawValue: $0) } ?? .us
 
     Task {
       do {


### PR DESCRIPTION
The region string passed to the Apptentive module was previously expected to be lowercase, but we don't want to depend on that. This lowercases the string before looking up which region (if any) it maps to. 